### PR TITLE
Made font.cpp more intuitive, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ![Super Haxagon](./resource/banner.png "Banner")
 
-This is a Super Hexagon clone for the Nintendo 3DS. This should run on both o3ds, n3ds, and ~~Citra homebrew environments~~ nevermind, it can't emulate it fast enough. The Makefile also creates a CFW compatible CIA too, for those who are into that kind of stuff. A banner is included.
+This is a Super Hexagon clone for the Nintendo 3DS. This should run on both o3ds, n3ds, and Citra homebrew environments. The Makefile also creates a CFW compatible CIA too, for those who are into that kind of stuff. A banner is included.
 
 ### Download
 
-None yet! This is still in development. You can either compile it for now by yourself or wait for me to make it stable enough for the masses.
+Downloads are available from the [releases page](https://github.com/RedInquisitive/Super-Haxagon/releases).
 
 Contributing to the project will help create a better game for everyone! If you would like to help, feel free to create a pull request. I know for a fact I messed up somewhere in the code here. If you are implementing a new feature, I'd be happy to acccept it! 
 

--- a/source/font.cpp
+++ b/source/font.cpp
@@ -1,23 +1,18 @@
 #include "font.h"
 
-BmpFont *font16 = NULL;
-BmpFont *font32 = NULL;
+BmpFont font16;
+BmpFont font32;
 
 void writeFont(Point p, const char* s, bool large) {
-	if(font16 == NULL) {
-		font16 = new BmpFont("romfs:/font16.bff"); //Load font file
+	if(!font16) {
+		font16.load("romfs:/font16.bff"); //Load font file
 	}
-	if(font32 == NULL) {
-		font32 = new BmpFont("romfs:/font32.bff"); //Load font file
+	if(!font32) {
+		font32.load("romfs:/font32.bff"); //Load font file
 	}
 	if(large) {
-		font32->drawStr(s, p.x, p.y, p.color);
+		font32.drawStr(s, p.x, p.y, p.color);
 	} else {
-		font16->drawStr(s, p.x, p.y, p.color);
+		font16.drawStr(s, p.x, p.y, p.color);
 	}
-}
-
-void freeFonts() {
-	font16->free();
-	font32->free();
 }

--- a/source/font.h
+++ b/source/font.h
@@ -12,7 +12,6 @@ extern "C" {
 #endif
 
 void writeFont(Point p, const char* s, bool large);
-void freeFonts();
 
 #ifdef __cplusplus
 }

--- a/source/main.c
+++ b/source/main.c
@@ -668,7 +668,6 @@ int main() {
 		}
 		g_renderedWalls = 0;
 	}
-	freeFonts();
 	freePatterns();
 	audioUnload();
 	ndspExit();


### PR DESCRIPTION
I noticed you were using pointers in font.cpp and dynamically allocating fonts when there is no reason to. I mean it still works fine, but it's just more intuitive if you don't do it that way. Also you don't need to call `free`; that function is unnecessary in most cases. If you don't free it manually, it's taken care of automatically in the destructor.

Though actually, the destructor wouldn't end up being called the way you wrote it, because you didn't `delete` the pointers. So there actually was a freeing step necessary the way you did it; you just didn't do it correctly. But the way I did it, allocating it statically, there's nothing that needs to be done to free it.

I also updated the readme to fix a couple things that were outdated. One is that it says Citra is too slow to emulate it. But switching to sf2dlib fixed that. You also said there aren't any binary downloads available; that's no longer true.

Great work so far, by the way!
