### PR TITLE
New record notification

### DIFF
--- a/source/draw.c
+++ b/source/draw.c
@@ -408,7 +408,7 @@ void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM) {
 void drawPlayGameBot(Level level, LiveLevel liveLevel, double fps) {
 	Point posLevelUp = {4,4};
 	Point posScore = {BOT_WIDTH - 4, 4};
-	Point posBest = {BOT_WIDTH - 4, 24};
+	Point posBest = {BOT_WIDTH - 4, 20};
 
 	drawBlackBot();
 
@@ -429,11 +429,12 @@ void drawPlayGameBot(Level level, LiveLevel liveLevel, double fps) {
 }
 
 //EXTERNAL
-void drawGameOverBot(int score, double fps, int frame) {
+void drawGameOverBot(int score, int highScore, double fps, int frames, int showText) {
 	Point posGameOver = {BOT_WIDTH / 2, 4};
 	Point posTime = {BOT_WIDTH / 2, 40};
-	Point posA = {BOT_WIDTH / 2, 70};
-	Point posB = {BOT_WIDTH / 2, 86};
+	Point posBest = {BOT_WIDTH / 2, 56};
+	Point posA = {BOT_WIDTH / 2, 78};
+	Point posB = {BOT_WIDTH / 2, 94};
 
 	drawBlackBot();
 
@@ -442,7 +443,15 @@ void drawGameOverBot(int score, double fps, int frame) {
 	writeFont(WHITE, posTime, scoreTime, FONT16, ALIGN_CENTER_C);
 	free(scoreTime);
 
-	if(frame == 0) {
+	if(score > highScore) {
+		writeFont(WHITE, posBest, "NEW RECORD!", FONT16, ALIGN_CENTER_C);
+	} else {
+		char* bestTime = getBestTime(highScore);
+		writeFont(WHITE, posBest, bestTime, FONT16, ALIGN_CENTER_C);
+		free(bestTime);
+	}
+
+	if(showText) {
 		writeFont(WHITE, posA, "PRESS A TO PLAY", FONT16, ALIGN_CENTER_C);
 		writeFont(WHITE, posB, "PRESS B TO QUIT", FONT16, ALIGN_CENTER_C);
 	}

--- a/source/draw.c
+++ b/source/draw.c
@@ -23,6 +23,12 @@ const int SHADOW_Y = -4;
 //The center of the screen
 const Point SCREEN_CENTER = {TOP_WIDTH/2, SCREEN_HEIGHT/2};
 
+//Record pulsing settings
+const Color PULSE_LOW = {0xFF, 0xFF, 0xFF, 0x7F};
+const Color PULSE_HIGH = {0xFF, 0xFF, 0xFF, 0xFF};
+const int PULSE_TIME = 75;
+const double PULSE_TIMES = 2.0;
+
 /** INTERNAL
  * Draws a simple triangle using an array of points and a color.
  * The array must have 3 points.
@@ -304,9 +310,9 @@ void drawPlayGame(Level level, LiveLevel liveLevel, double offset, double sides)
 	Color BG2 = interpolateColor(level.colorsBG2[liveLevel.indexBG2], level.colorsBG2[liveLevel.nextIndexBG2], percentTween);
 
 	//fix for triangle levels
-	int diagnal = (sides >= 3 && sides < 4 ? SCREEN_TOP_DIAG_FROM_CENTER * 2 : SCREEN_TOP_DIAG_FROM_CENTER);
+	int diagonal = (sides >= 3 && sides < 4 ? SCREEN_TOP_DIAG_FROM_CENTER * 2 : SCREEN_TOP_DIAG_FROM_CENTER);
 
-	drawBackground(BG1, BG2, SCREEN_CENTER, diagnal, liveLevel.rotation, sides);
+	drawBackground(BG1, BG2, SCREEN_CENTER, diagonal, liveLevel.rotation, sides);
 
 	//draw shadows
 	Point offsetFocus = {SCREEN_CENTER.x + SHADOW_X, SCREEN_CENTER.y + SHADOW_Y};
@@ -418,7 +424,12 @@ void drawPlayGameBot(Level level, LiveLevel liveLevel, double fps) {
 	free(scoreTime);
 
 	if(level.highScore > 0 && liveLevel.score > level.highScore) {
-		writeFont(WHITE, posBest, "NEW RECORD!", FONT16, ALIGN_RIGHT_C);
+		Color textColor = WHITE;
+		if (liveLevel.score - level.highScore <= PULSE_TIMES * PULSE_TIME) {
+			double percent = getPulse(liveLevel.score, PULSE_TIME, level.highScore);
+			textColor = interpolateColor(PULSE_LOW, PULSE_HIGH, percent);
+		}
+		writeFont(textColor, posBest, "NEW RECORD!", FONT16, ALIGN_RIGHT_C);
 	} else {
 		char* bestTime = getBestTime(level.highScore);
 		writeFont(WHITE, posBest, bestTime, FONT16, ALIGN_RIGHT_C);
@@ -444,7 +455,9 @@ void drawGameOverBot(int score, int highScore, double fps, int frames, int showT
 	free(scoreTime);
 
 	if(score > highScore) {
-		writeFont(WHITE, posBest, "NEW RECORD!", FONT16, ALIGN_CENTER_C);
+		double percent = getPulse(frames, PULSE_TIME, 0);
+		Color pulse = interpolateColor(PULSE_LOW, PULSE_HIGH, percent);
+		writeFont(pulse, posBest, "NEW RECORD!", FONT16, ALIGN_CENTER_C);
 	} else {
 		char* bestTime = getBestTime(highScore);
 		writeFont(WHITE, posBest, bestTime, FONT16, ALIGN_CENTER_C);

--- a/source/draw.c
+++ b/source/draw.c
@@ -29,7 +29,7 @@ const Point SCREEN_CENTER = {TOP_WIDTH/2, SCREEN_HEIGHT/2};
  */
 void drawTriangle(Color color, Point points[3]) {
 	long paint = RGBA8(color.r,color.g,color.b,color.a);
-	
+
 	//draws a triangle on the correct axis
 	sf2d_draw_triangle(
 		points[0].x, SCREEN_HEIGHT - 1 - points[0].y,
@@ -70,14 +70,14 @@ void drawMovingWall(Color color, Point focus, LiveWall wall, double rotation, do
 	double distance = wall.distance;
 	double height = wall.height;
 	if(distance + height < DEF_HEX_FULL_LEN) return; //TOO_CLOSE;
-	if(distance > SCREEN_TOP_DIAG_FROM_CENTER) return; //TOO_FAR; 
+	if(distance > SCREEN_TOP_DIAG_FROM_CENTER) return; //TOO_FAR;
 	if(wall.side >= sides) return; //NOT_IN_RANGE
-	
+
 	if(distance < DEF_HEX_FULL_LEN - 2.0) {//so the distance is never negative as it enters.
 		height -= DEF_HEX_FULL_LEN - 2.0 - distance;
 		distance = DEF_HEX_FULL_LEN - 2.0; //Should never be 0!!!
 	}
-	
+
 	Point edges[4] = {0};
 	edges[0] = calcPointWall(focus, rotation, OVERFLOW_OFFSET, distance, wall.side + 1, sides);
 	edges[1] = calcPointWall(focus, rotation, OVERFLOW_OFFSET, distance + height, wall.side + 1, sides);
@@ -92,11 +92,11 @@ void drawMovingWall(Color color, Point focus, LiveWall wall, double rotation, do
  * an "Explosion" effect if you use "offset". (for game overs)
  */
 void drawMovingPatterns(Color color, Point focus, LiveLevel live, double offset, double sides) {
-	
+
 	//for all patterns
 	for(int iPattern = 0; iPattern < TOTAL_PATTERNS_AT_ONE_TIME; iPattern++) {
 		LivePattern pattern = live.patterns[iPattern];
-		
+
 		//draw all walls
 		for(int iWall = 0; iWall < pattern.numWalls; iWall++) {
 			LiveWall wall = pattern.walls[iWall];
@@ -112,32 +112,32 @@ void drawMovingPatterns(Color color, Point focus, LiveLevel live, double offset,
  */
 void drawRegular(Color color, Point focus, int height, double rotation, double sides) {
 	int exactSides = (int)(sides + 0.99999);
-	
+
 	Point* edges = malloc(sizeof(Point) * exactSides);
 	if(!edges) panic("POLYGON ERROR!", "There was an error allocating memory for "
 			"a regular polygon. This should never happen.", DEF_DEBUG, 0x0000DEAD);
-	
+
 	//calculate the triangle backwards so it overlaps correctly.
 	for(int i = 0; i < exactSides; i++) {
 		edges[i].x = (int)(height * cos(rotation + (double)i * TAU/sides) + (double)(focus.x) + 0.5);
 		edges[i].y = (int)(height * sin(rotation + (double)i * TAU/sides) + (double)(focus.y) + 0.5);
 	}
-	
+
 	Point triangle[3];
 	triangle[0] = focus;
-	
+
 	//connect last triangle edge to first
 	triangle[1] = edges[exactSides - 1];
 	triangle[2] = edges[0];
 	drawTriangle(color, triangle);
-	
+
 	//draw rest of regular polygon
 	for(int i = 0; i < exactSides - 1; i++) {
 		triangle[1] = edges[i];
 		triangle[2] = edges[i + 1];
 		drawTriangle(color, triangle);
 	}
-	
+
 	free(edges);
 }
 
@@ -146,39 +146,39 @@ void drawRegular(Color color, Point focus, int height, double rotation, double s
  */
 void drawBackground(Color color1, Color color2, Point focus, double height, double rotation, double sides) {
 	int exactSides = (int)(sides + 0.99999);
-	
+
 	//solid background.
 	Point position = {0,0};
 	Point size = {TOP_WIDTH, SCREEN_HEIGHT};
 	drawRect(color1, position, size);
-	
+
 	//This draws the main background.
 	Point* edges = malloc(sizeof(Point) * exactSides);
 	if(!edges) panic("BG ERROR!", "There was an error allocating memory for "
 			"the background. This should never happen.", DEF_DEBUG, 0x0000DEAD);
-	
+
 	for(int i = 0; i < exactSides; i++) {
 		edges[i].x = (int)(height * cos(rotation + (double)i * TAU/sides) + (double)(focus.x) + 0.5);
 		edges[i].y = (int)(height * sin(rotation + (double)i * TAU/sides) + (double)(focus.y) + 0.5);
 	}
-	
+
 	Point triangle[3];
 	triangle[0] = focus;
-	
+
 	//if the sides is odd we need to "make up a color" to put in the gap between the last and first color
 	if(exactSides % 2) {
 		triangle[1] = edges[exactSides - 1];
 		triangle[2] = edges[0];
 		drawTriangle(interpolateColor(color1, color2, 0.5f), triangle);
 	}
-	
+
 	//Draw the rest of the triangles
 	for(int i = 0; i < exactSides - 1; i = i + 2) {
 		triangle[1] = edges[i];
 		triangle[2] = edges[i + 1];
 		drawTriangle(color2, triangle);
 	}
-	
+
 	free(edges);
 }
 
@@ -219,7 +219,7 @@ void drawMainMenu(GlobalData data, MainMenu menu) {
 	if(menu.transitionDirection == -1) { //if the user is going to the left, flip the radians so the animation plays backwards.
 		rotation *= -1.0;
 	}
-	
+
 	//Colors
 	Color FG;
 	Color BG1;
@@ -237,18 +237,18 @@ void drawMainMenu(GlobalData data, MainMenu menu) {
 		BG1 = level.colorsBG1[0];
 		BG2 = level.colorsBG2[0];
 		BG3 = level.colorsBG2[0]; //same as BG2
-	} 
-	
+	}
+
 	Point focus = {TOP_WIDTH/2, SCREEN_HEIGHT/2 - 60};
 	Point offsetFocus = {focus.x + SHADOW_X, focus.y + SHADOW_Y};
-	
+
 	//home screen always has 6 sides.
-	drawBackground(BG1, BG2, focus, SCREEN_TOP_DIAG_FROM_CENTER, rotation, 6.0); 
-	
+	drawBackground(BG1, BG2, focus, SCREEN_TOP_DIAG_FROM_CENTER, rotation, 6.0);
+
 	//shadows
 	drawRegular(SHADOW, offsetFocus, DEF_HEX_FULL_LEN, rotation, 6.0);
 	drawHumanCursor(SHADOW, offsetFocus, TAU/4.0, 0);
-	
+
 	//geometry
 	drawRegular(FG, focus, DEF_HEX_FULL_LEN, rotation, 6.0);
 	drawRegular(BG3, focus, DEF_HEX_FULL_LEN - DEF_HEX_BORDER_LEN, rotation, 6.0);
@@ -273,7 +273,7 @@ void drawMainMenu(GlobalData data, MainMenu menu) {
 		{infoSize.x + TRIANGLE_WIDTH, SCREEN_HEIGHT - 1}};
 	drawRect(TRANSP, infoPos, infoSize);
 	drawTriangle(TRANSP, infoTriangle);
-	
+
 	//score block with triangle
 	Point timePos = {0, posTime.y - 3};
 	Point timeSize = {10/*chars?*/ * 16 + 4, 16 + 7};
@@ -296,24 +296,24 @@ void drawMainMenu(GlobalData data, MainMenu menu) {
 
 //EXTERNAL
 void drawPlayGame(Level level, LiveLevel liveLevel, double offset, double sides) {
-	
+
 	//calculate colors
 	double percentTween = (double)(liveLevel.tweenFrame) / (double)(level.speedPulse);
 	Color FG = interpolateColor(level.colorsFG[liveLevel.indexFG], level.colorsFG[liveLevel.nextIndexFG], percentTween);
 	Color BG1 = interpolateColor(level.colorsBG1[liveLevel.indexBG1], level.colorsBG1[liveLevel.nextIndexBG1], percentTween);
 	Color BG2 = interpolateColor(level.colorsBG2[liveLevel.indexBG2], level.colorsBG2[liveLevel.nextIndexBG2], percentTween);
-	
-	//fix for triangle levels 
+
+	//fix for triangle levels
 	int diagnal = (sides >= 3 && sides < 4 ? SCREEN_TOP_DIAG_FROM_CENTER * 2 : SCREEN_TOP_DIAG_FROM_CENTER);
-	
+
 	drawBackground(BG1, BG2, SCREEN_CENTER, diagnal, liveLevel.rotation, sides);
-	
+
 	//draw shadows
 	Point offsetFocus = {SCREEN_CENTER.x + SHADOW_X, SCREEN_CENTER.y + SHADOW_Y};
 	drawMovingPatterns(SHADOW, offsetFocus, liveLevel, offset, sides);
 	drawRegular(SHADOW, offsetFocus, DEF_HEX_FULL_LEN, liveLevel.rotation, sides);
 	drawHumanCursor(SHADOW, offsetFocus, liveLevel.cursorPos, liveLevel.rotation);
-	
+
 	//draw real thing
 	drawMovingPatterns(FG, SCREEN_CENTER, liveLevel, offset, sides);
 	drawRegular(FG, SCREEN_CENTER, DEF_HEX_FULL_LEN, liveLevel.rotation, sides);
@@ -333,11 +333,11 @@ void drawPanic(const char* message, const char* file, const char* function, int 
 	Point posButtons = {TOP_WIDTH / 2, posCheck.y + 16 + 2};
 
 	drawBlack();
-	
+
 	writeFont(WHITE, posAwwSnap, "AWW SNAP!", FONT32, ALIGN_CENTER_C);
 	writeFont(WHITE, posCrash, "LOOKS LIKE THE GAME CRASHED!", FONT16, ALIGN_CENTER_C);
 	writeFont(WHITE, posInfo, "HERE'S SOME INFORMATION:", FONT16, ALIGN_CENTER_C);
-	
+
 	//WARNING: PROGRAM WILL BE MAD IF writeFont(...) EVER MESSES WITH THE STRING!
 	writeFont(WHITE, posMessage, (char*)message, FONT16, ALIGN_CENTER_C);
 	writeFont(WHITE, posFile, (char*)file, FONT16, ALIGN_CENTER_C);
@@ -405,16 +405,25 @@ void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM) {
 }
 
 //EXTERNAL
-void drawPlayGameBot(FileString name, int score, double fps) {
+void drawPlayGameBot(Level level, LiveLevel liveLevel, double fps) {
 	Point posLevelUp = {4,4};
 	Point posScore = {BOT_WIDTH - 4, 4};
+	Point posBest = {BOT_WIDTH - 4, 24};
 
 	drawBlackBot();
 
-	char* scoreTime  = getScoreTime(score);
+	char* scoreTime = getScoreTime(liveLevel.score);
 	writeFont(WHITE, posScore, scoreTime, FONT16, ALIGN_RIGHT_C);
-	writeFont(WHITE, posLevelUp, getScoreText(score), FONT16, ALIGN_LEFT_C);
+	writeFont(WHITE, posLevelUp, getScoreText(liveLevel.score), FONT16, ALIGN_LEFT_C);
 	free(scoreTime);
+
+	if(level.highScore > 0 && liveLevel.score > level.highScore) {
+		writeFont(WHITE, posBest, "NEW RECORD!", FONT16, ALIGN_RIGHT_C);
+	} else {
+		char* bestTime = getBestTime(level.highScore);
+		writeFont(WHITE, posBest, bestTime, FONT16, ALIGN_RIGHT_C);
+		free(bestTime);
+	}
 
 	drawFramerate(fps);
 }

--- a/source/draw.h
+++ b/source/draw.h
@@ -7,17 +7,17 @@ void drawMainMenu(GlobalData data, MainMenu menu);
 void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM);
 
 /**
- * Base render for the game. Draws based on a single active level. 
+ * Base render for the game. Draws based on a single active level.
  */
 void drawPlayGame(Level level, LiveLevel liveLevel, double offset, double sides);
-void drawPlayGameBot(FileString name, int score, double fps);
+void drawPlayGameBot(Level level, LiveLevel liveLevel, double fps);
 
-/** 
+/**
  * Renders game over text.
  */
-void drawGameOverBot(int score, double fps, int frame);
+void drawGameOverBot(int score, int highScore, double fps, int frame, int showText);
 
-/** 
+/**
  * Draws the crash screen.
  * :(
  */
@@ -34,4 +34,3 @@ void drawWarning(const char* message, const char* file, const char* function, in
  * Draws a completely black screen on the bottom of the 3DS.
  */
 void drawBlackBot(void);
-

--- a/source/logic.c
+++ b/source/logic.c
@@ -344,12 +344,14 @@ GameState doPlayGame(Level level, LiveLevel* gameOver, Track levelUp) {
 
 //EXTERNAL
 GameState doGameOver(Level level, LiveLevel gameOver) {
-	int frames = FRAMES_PER_GAME_OVER;
+	int frames = 0;
 	double offsetDistance = 1.0;
 	int sides = gameOver.patterns[0].sides;
 	while(aptMainLoop()) {
 
 		//LOGIC
+		frames++;
+
 		gameOver.rotation += GAME_OVER_ROT_SPEED;
 		if(gameOver.rotation >= TAU) gameOver.rotation -= TAU;
 		if(gameOver.rotation < 0) gameOver.rotation  += TAU;
@@ -357,17 +359,16 @@ GameState doGameOver(Level level, LiveLevel gameOver) {
 		ButtonState press = getButton();
 		if(press == QUIT) return PROGRAM_QUIT;
 
-		if(frames > 0) {
-			frames--;
+		if(frames <= FRAMES_PER_GAME_OVER) {
 			offsetDistance *= GAME_OVER_ACCEL_RATE;
 		}
-		if(frames == 1) {
+		if(frames == FRAMES_PER_GAME_OVER - 1) {
 			for(int i = 0; i < TOTAL_PATTERNS_AT_ONE_TIME; i++){
 				freeLivePattern(gameOver.patterns[i]);
 				gameOver.patterns[i].numWalls = 0;
 			}
 		}
-		if(frames == 0) {
+		if(frames >= FRAMES_PER_GAME_OVER) {
 			switch(press) {
 			case SELECT:
 				return PLAYING;
@@ -377,13 +378,12 @@ GameState doGameOver(Level level, LiveLevel gameOver) {
 			}
 		}
 
-
 		//DRAW
 		sf2d_start_frame(GFX_TOP, GFX_LEFT);
 		drawPlayGame(level, gameOver, offsetDistance, (double)sides);
 		sf2d_end_frame();
 		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		drawGameOverBot(gameOver.score, sf2d_get_fps(), frames);
+		drawGameOverBot(gameOver.score, level.highScore, sf2d_get_fps(), frames, frames >= FRAMES_PER_GAME_OVER);
 		sf2d_end_frame();
 		sf2d_swapbuffers();
 	}

--- a/source/main.c
+++ b/source/main.c
@@ -19,7 +19,7 @@ const char* NAME_ROMFS_SCORE = "sdmc:" DIR_3DS DIR_DATA DIR_HAXAGON FILE_SCORE_R
 const char* NAME_SDMC_SCORE = "sdmc:" DIR_3DS DIR_DATA DIR_HAXAGON FILE_SCORE_SDMC;
 
 int main() {
-	
+
 	//3ds init
 	sf2d_init();
 	sf2d_set_vblank_wait(1);
@@ -28,20 +28,20 @@ int main() {
 	sdmcInit();
 	ndspInit();
 	ndspSetOutputMode(NDSP_OUTPUT_STEREO);
-	
+
 	//pattern loading
 	LoadedState loaded = NOT_LOADED;
 	GlobalData data = EMPTY_GLOBAL_DATA;
 	FILE* fileData;
 	const char*  scorePath;
 	data.loaded = 0;
-	
+
 	//program init
 	srand(svcGetSystemTick());
-	
+
 	//audio loading
 	Track begin;
-	Track hexagon; 
+	Track hexagon;
 	Track over;
 	Track rotate;
 	Track mainMenu;
@@ -55,13 +55,13 @@ int main() {
 	audioLoad("romfs:/bgm/pamgaea.wav", &mainMenu, 5);
 	int channelBGM = 6; //Last channel + 1. Remember to update this!
 	int showGetBGM = 1; //Used to hide the get BGM info after a button press.
-	
+
 	//level selection and game over
 	int nlevel = 0;
 	int nLastLevel = -1;
 	Level level = EMPTY_LEVEL;
 	LiveLevel gameOver = EMPTY_LIVE_LEVEL;
-	
+
 	//Controller
 	GameState state = SWITCH_LOAD_LOCATION;
 	while(state != PROGRAM_QUIT) {
@@ -125,6 +125,7 @@ int main() {
 
 			//replace and save high score if needed.
 			if(gameOver.score > level.highScore) {
+				level.highScore = gameOver.score;
 				data.levels[nlevel].highScore = gameOver.score;
 				putScores(scorePath, data);
 			}
@@ -132,10 +133,10 @@ int main() {
 		case PROGRAM_QUIT:;
 		}
 	}
-	
+
 	//level free
 	freeData(data);
-	
+
 	//audio free
 	audioFree(&begin);
 	audioFree(&hexagon);
@@ -144,12 +145,12 @@ int main() {
 	audioFree(&mainMenu);
 	audioFree(&levelUp);
 	audioFree(&bgm);
-	
+
 	//close GFX
 	sf2d_fini();
-	gfxExit();	
-	romfsExit();	
+	gfxExit();
+	romfsExit();
 	sdmcExit();
-	ndspExit();	
+	ndspExit();
 	return 0;
 }

--- a/source/util.c
+++ b/source/util.c
@@ -39,10 +39,10 @@ void panic(const char* title, const char* message, const char* file, const char*
 		sf2d_swapbuffers();
 	}
 	sf2d_fini();
-	gfxExit();	
-	romfsExit();	
+	gfxExit();
+	romfsExit();
 	sdmcExit();
-	ndspExit();	
+	ndspExit();
 	exit(1);
 }
 
@@ -114,24 +114,24 @@ ButtonState getButton(void) {
 	u32 kHold = hidKeysHeld();
 	if(kDown & KEY_A ) {
 		return SELECT;
-	} 
+	}
 	if(kDown & KEY_START ) {
 		return QUIT;
-	} 
+	}
 	if(kDown & KEY_B ) {
 		return BACK;
-	} 
+	}
 	if(kHold & (KEY_R | KEY_ZR | KEY_CSTICK_RIGHT | KEY_CPAD_RIGHT | KEY_DRIGHT | KEY_X)) {
 		return DIR_RIGHT;
-	} 
+	}
 	if(kHold & (KEY_L | KEY_ZL | KEY_CSTICK_LEFT | KEY_CPAD_LEFT | KEY_DLEFT | KEY_Y)) {
 		return DIR_LEFT;
-	} 
+	}
 	return NOTHING;
 }
 
 //EXTERNAL
- char* getScoreText(int score) {
+char* getScoreText(int score) {
 	if(score < 10 * 60) return "SPACE";
 	if(score < 20 * 60) return "POINT";
 	if(score < 30 * 60) return "LINE";
@@ -139,22 +139,22 @@ ButtonState getButton(void) {
 	if(score < 50 * 60) return "SQUARE";
 	if(score < 60 * 60) return "PENTAGON";
 	return "HEXAGON";
- }
+}
 
- //EXTERNAL
- char* getScoreTime(int score) {
-		char* buffer = malloc(sizeof(char) * 12 + 1);
-		int scoreInt = (int)((double)score/60.0);
-		int decimalPart = (int)(((double)score/60.0 - (double)scoreInt) * 100.0);
-		snprintf(buffer, 12+1, "TIME: %03d:%02d", scoreInt, decimalPart);
-		return buffer;
- }
+//EXTERNAL
+char* getScoreTime(int score) {
+	char* buffer = malloc(sizeof(char) * 12 + 1);
+	int scoreInt = (int)((double)score/60.0);
+	int decimalPart = (int)(((double)score/60.0 - (double)scoreInt) * 100.0);
+	snprintf(buffer, 12+1, "TIME: %03d:%02d", scoreInt, decimalPart);
+	return buffer;
+}
 
- //EXTERNAL
- char* getBestTime(int score) {
-		char* buffer = malloc(sizeof(char) * 12 + 1);
-		int scoreInt = (int)((double)score/60.0);
-		int decimalPart = (int)(((double)score/60.0 - (double)scoreInt) * 100.0);
-		snprintf(buffer, 12+1, "BEST: %03d:%02d", scoreInt, decimalPart);
-		return buffer;
- }
+//EXTERNAL
+char* getBestTime(int score) {
+	char* buffer = malloc(sizeof(char) * 12 + 1);
+	int scoreInt = (int)((double)score/60.0);
+	int decimalPart = (int)(((double)score/60.0 - (double)scoreInt) * 100.0);
+	snprintf(buffer, 12+1, "BEST: %03d:%02d", scoreInt, decimalPart);
+	return buffer;
+}

--- a/source/util.c
+++ b/source/util.c
@@ -160,10 +160,10 @@ char* getBestTime(int score) {
 }
 
 //EXTERNAL
-double getPulse(int place, int range, int start) {
-	place -= start;
+double getPulse(int frame, int range, int start) {
+	frame -= start;
 	// Alternate algorithm:
-	//double percent = sin((double)place * <speed>) / 2.0 + 0.5;
-	return fabs(((double)(place % range * 2) - (double)range)
-							  / (double)range);
+	//double percent = sin((double)frame * <speed>) / 2.0 + 0.5;
+	return fabs(((double)(frame % range * 2) - (double)frame)
+							  / (double)frame);
 }

--- a/source/util.c
+++ b/source/util.c
@@ -76,7 +76,7 @@ void warning(const char* title, const char* message, const char* file, const cha
 
 //EXTERNAL
 double linear(double start, double end, double percent) {
-    return (end - start) * percent + start;
+	return (end - start) * percent + start;
 }
 
 //EXTERNAL
@@ -157,4 +157,13 @@ char* getBestTime(int score) {
 	int decimalPart = (int)(((double)score/60.0 - (double)scoreInt) * 100.0);
 	snprintf(buffer, 12+1, "BEST: %03d:%02d", scoreInt, decimalPart);
 	return buffer;
+}
+
+//EXTERNAL
+double getPulse(int place, int range, int start) {
+	place -= start;
+	// Alternate algorithm:
+	//double percent = sin((double)place * <speed>) / 2.0 + 0.5;
+	return fabs(((double)(place % range * 2) - (double)range)
+							  / (double)range);
 }

--- a/source/util.h
+++ b/source/util.h
@@ -53,3 +53,10 @@ char* getScoreText(int score);
   */
 char* getScoreTime(int score);
 char* getBestTime(int score);
+
+/**
+ * Will pulse between 0.0 and 1.0 at the speed given (in tenths of a
+ * second).
+ * start is when the pulse should (have) start(ed).
+ */
+double getPulse(int frame, int speed, int start);


### PR DESCRIPTION
The level now always shows the best time under the current time, both in-level and on the game over screen.
When you get a new record on a level, the best time will be replaced by the text "NEW RECORD!", which will pulse twice.
Afterwards, on the game over screen, the text "NEW RECORD!" will replace the best time and pulse indefinitely.
(Also, my editor automatically removes trailing whitespace, so that will show up in the diffs.)