### PR TITLE
Hide prompt to load external levels if none exist

### DIFF
--- a/source/draw.c
+++ b/source/draw.c
@@ -387,7 +387,7 @@ void drawBlackBot(void) {
 }
 
 //EXTERNAL
-void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM) {
+void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM, int showLoadLevels) {
 	Point posButton = {4, 4};
 	Point posLocation = {210, 4};
 	Point posLevels = {4, posLocation.y + 16 + 1};
@@ -396,11 +396,12 @@ void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM) {
 	Point posDownload3 = {4, posDownload2.y + 16 + 1};
 
 	drawBlackBot();
-	writeFont(WHITE, posButton, "PRESS B TO LOAD", FONT16, ALIGN_LEFT_C);
-	if(loaded == ROMFS) writeFont(WHITE, posLocation, "SDMC", FONT16, ALIGN_LEFT_C);
-	if(loaded == SDMC) writeFont(WHITE, posLocation, "ROMFS", FONT16, ALIGN_LEFT_C);
-	writeFont(WHITE, posLevels, "LEVELS", FONT16, ALIGN_LEFT_C);
-
+	if(showLoadLevels){
+		writeFont(WHITE, posButton, "PRESS B TO LOAD", FONT16, ALIGN_LEFT_C);
+		if(loaded == ROMFS) writeFont(WHITE, posLocation, "SDMC", FONT16, ALIGN_LEFT_C);
+		if(loaded == SDMC) writeFont(WHITE, posLocation, "ROMFS", FONT16, ALIGN_LEFT_C);
+		writeFont(WHITE, posLevels, "LEVELS", FONT16, ALIGN_LEFT_C);
+	}
 	if(showGetBGM) {
 		writeFont(WHITE, posDownload, "GET BGM FROM GITHUB: ", FONT16, ALIGN_LEFT_C);
 		writeFont(WHITE, posDownload2, "REDINQUISITIVE/", FONT16, ALIGN_LEFT_C);

--- a/source/draw.h
+++ b/source/draw.h
@@ -4,7 +4,7 @@
  * Draws the main menu of the program based on loaded data and main menu variables.
  */
 void drawMainMenu(GlobalData data, MainMenu menu);
-void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM);
+void drawMainMenuBot(LoadedState loaded, double fps, int showGetBGM, int showLoadLevels);
 
 /**
  * Base render for the game. Draws based on a single active level.

--- a/source/logic.c
+++ b/source/logic.c
@@ -141,7 +141,7 @@ double getFurthestWallDistance(LivePattern pattern) {
 }
 
 //EXTERNAL
-GameState doMainMenu(GlobalData data, LoadedState loaded, Track select, int* level, int showGetBGM) {
+GameState doMainMenu(GlobalData data, LoadedState loaded, Track select, int* level, int showGetBGM, int showLoadLevels) {
 	MainMenu menu = {0};
 	menu.level = *level;
 	while(aptMainLoop()) {
@@ -152,7 +152,8 @@ GameState doMainMenu(GlobalData data, LoadedState loaded, Track select, int* lev
 		if(!(menu.transitionDirection)) {
 			switch(press) {
 			case BACK:
-				return SWITCH_LOAD_LOCATION;
+				if(showLoadLevels) return SWITCH_LOAD_LOCATION;
+				break;
 			case SELECT:
 				*level = menu.level;
 				return PLAYING;
@@ -180,13 +181,13 @@ GameState doMainMenu(GlobalData data, LoadedState loaded, Track select, int* lev
 			menu.transitionFrame = 0;
 			menu.transitionDirection = 0;
 		}
-
+		
 		//DRAW
 		sf2d_start_frame(GFX_TOP, GFX_LEFT);
 		drawMainMenu(data, menu);
 		sf2d_end_frame();
 		sf2d_start_frame(GFX_BOTTOM, GFX_LEFT);
-		drawMainMenuBot(loaded, sf2d_get_fps(), showGetBGM);
+		drawMainMenuBot(loaded, sf2d_get_fps(), showGetBGM, showLoadLevels);
 		sf2d_end_frame();
 		sf2d_swapbuffers();
 	}

--- a/source/logic.h
+++ b/source/logic.h
@@ -4,7 +4,7 @@
  * Logic for working the main menu, along  with a selection sound.
  * Modifys the address of level to the currently selected level upon return.
  */
-GameState doMainMenu(GlobalData data, LoadedState loaded, Track select, int* level, int showGetBGM);
+GameState doMainMenu(GlobalData data, LoadedState loaded, Track select, int* level, int showGetBGM, int showLoadLevels);
 
 /** 
  * Plays a level.


### PR DESCRIPTION
It was annoying me to always crash when pressing "B" on the main menu, so I added this to check for external levels, disabling the ability to switch load location if none are found.

I am eager to hear about what can be improved in this pull request, even if it is not accepted.