### PR TITLE
Partial path in Platform::loadFont()

### DIFF
--- a/source/Core/Game.cpp
+++ b/source/Core/Game.cpp
@@ -21,8 +21,8 @@ namespace SuperHaxagon {
 		_sfxLevelUp = platform.loadAudio("/sound/level", Stream::DIRECT, Location::ROM);
 		_sfxWonderful = platform.loadAudio("/sound/wonderful", Stream::DIRECT, Location::ROM);
 
-		_small = platform.loadFont(platform.getPath("/bump-it-up", Location::ROM), 16);
-		_large = platform.loadFont(platform.getPath("/bump-it-up", Location::ROM), 32);
+		_small = platform.loadFont("/bump-it-up", 16);
+		_large = platform.loadFont("/bump-it-up", 32);
 
 		_twister = platform.getTwister();
 	}

--- a/source/Driver/SFML/PlatformSFML.cpp
+++ b/source/Driver/SFML/PlatformSFML.cpp
@@ -63,8 +63,8 @@ namespace SuperHaxagon {
 		return std::make_unique<AudioLoaderSFML>(getPath(path, location), stream);
 	}
 
-	std::unique_ptr<Font> PlatformSFML::loadFont(const std::string& path, const int size) {
-		return std::make_unique<FontSFML>(*this, path, static_cast<float>(size));
+	std::unique_ptr<Font> PlatformSFML::loadFont(const std::string& partial, const int size) {
+		return std::make_unique<FontSFML>(*this, getPath(partial, Location::ROM), static_cast<float>(size));
 	}
 
 	void PlatformSFML::playSFX(AudioLoader& audio) {

--- a/source/Driver/SFML/PlatformSFML.cpp
+++ b/source/Driver/SFML/PlatformSFML.cpp
@@ -59,8 +59,8 @@ namespace SuperHaxagon {
 		return dilation > 4.0f ? 4.0f : (dilation < 0.05f ? 0.05f : dilation);
 	}
 
-	std::unique_ptr<AudioLoader> PlatformSFML::loadAudio(const std::string& path, Stream stream, Location location) {
-		return std::make_unique<AudioLoaderSFML>(getPath(path, location), stream);
+	std::unique_ptr<AudioLoader> PlatformSFML::loadAudio(const std::string& partial, Stream stream, Location location) {
+		return std::make_unique<AudioLoaderSFML>(getPath(partial, location), stream);
 	}
 
 	std::unique_ptr<Font> PlatformSFML::loadFont(const std::string& partial, const int size) {


### PR DESCRIPTION
This makes it consistent with `Platform::loadAudio()`.