### PR TITLE
Allow custom homescreen music

### DIFF
--- a/source/Core/Game.cpp
+++ b/source/Core/Game.cpp
@@ -93,6 +93,18 @@ namespace SuperHaxagon {
 		}
 	}
 
+	void Game::playTitleMusic() {
+		// First, try to load from the SD card if the player wants something custom
+		_bgm = _platform.loadMusic("/title", Location::USER);
+
+		if (!_bgm) _bgm = _platform.loadMusic("/bgm/bleepingDemo", Location::ROM);
+
+		if (_bgm) {
+			_bgm->setLoop(true);
+			_bgm->play();
+		}
+	}
+
 	void Game::playMusic(const std::string& music, const Location location, const bool loadMetadata, const bool loop) {
 		const auto base = "/bgm" + music;
 

--- a/source/Core/Game.hpp
+++ b/source/Core/Game.hpp
@@ -29,6 +29,7 @@ namespace SuperHaxagon {
 		~Game();
 
 		void run();
+		void playTitleMusic();
 		void playMusic(const std::string& music, Location location, bool loadMetadata, bool loop = true);
 		void playEffect(SoundEffect effect) const;
 		void addLevel(std::unique_ptr<LevelFactory> level);

--- a/source/Driver/Common/SFML/MusicSFML.cpp
+++ b/source/Driver/Common/SFML/MusicSFML.cpp
@@ -2,6 +2,8 @@
 
 #include <SFML/Audio.hpp>
 
+#include <filesystem>
+
 namespace SuperHaxagon {
 	struct Music::MusicImpl {
 		explicit MusicImpl(std::unique_ptr<sf::Music> music) : music(std::move(music)) {}
@@ -37,7 +39,13 @@ namespace SuperHaxagon {
 		return _impl->music->getPlayingOffset().asSeconds();
 	}
 
-	std::unique_ptr<Music> createMusic(std::unique_ptr<sf::Music> music) {
+	std::unique_ptr<Music> createMusic(const std::string& path) {
+		if (!std::filesystem::exists(path)) return nullptr;
+
+		auto music = std::make_unique<sf::Music>();
+		auto loaded = music->openFromFile(path);
+		if (!loaded) return nullptr;
+
 		return std::make_unique<Music>(std::make_unique<Music::MusicImpl>(std::move(music)));
 	}
 }

--- a/source/Driver/Common/SFML/PlatformSFML.cpp
+++ b/source/Driver/Common/SFML/PlatformSFML.cpp
@@ -16,7 +16,7 @@
 #include <deque>
 
 namespace SuperHaxagon {
-	std::unique_ptr<Music> createMusic(std::unique_ptr<sf::Music> music);
+	std::unique_ptr<Music> createMusic(const std::string& path);
 	Screen createScreen(sf::RenderWindow& window);
 	std::unique_ptr<Sound> createSound(const std::string& path);
 	std::unique_ptr<Font> createFont(sf::RenderWindow& renderWindow, const std::string& path, int size);
@@ -151,11 +151,7 @@ namespace SuperHaxagon {
 	}
 
 	std::unique_ptr<Music> Platform::loadMusic(const std::string& base, const Location location) const {
-		auto music = std::make_unique<sf::Music>();
-		auto loaded = music->openFromFile(getPath(base, location) + ".ogg");
-		if (!loaded) return nullptr;
-
-		return createMusic(std::move(music));
+		return createMusic(getPath(base, location) + ".ogg");
 	}
 
 	Screen& Platform::getScreen() {

--- a/source/States/Menu.cpp
+++ b/source/States/Menu.cpp
@@ -37,7 +37,7 @@ namespace SuperHaxagon {
 	Menu::~Menu() = default;
 
 	void Menu::enter() {
-		_game.playMusic("/bleepingDemo", Location::ROM, false);
+		_game.playTitleMusic();
 
 		const auto curPos = _game.getCam().currentPos(CameraLayer::MAIN);
 


### PR DESCRIPTION
Fixes #35

Try placing title.ogg (inside of werq.zip) in `sdmc:/3ds/data/haxagon/` right next to your scores.db

Of course, this means you can change the title music to whatever .ogg file you want as well.

[SuperHaxagon.3dsx.zip](https://github.com/user-attachments/files/19100557/SuperHaxagon.3dsx.zip)
[SuperHaxagon.cia.zip](https://github.com/user-attachments/files/19100558/SuperHaxagon.cia.zip)
[werq.zip](https://github.com/user-attachments/files/19100567/werq.zip)
