### PR TITLE
Adjust speed of cursor left/right movement to match wall speed.

### DIFF
--- a/source/Factories/LevelFactory.cpp
+++ b/source/Factories/LevelFactory.cpp
@@ -75,7 +75,6 @@ namespace SuperHaxagon {
 	std::unique_ptr<Level> LevelFactory::instantiate(Twist& rng, float renderDistance, float rotation, float cursorPos) const {
 		return std::make_unique<Level>(*this, rng, renderDistance, rotation, cursorPos);
 	}
-
 	bool LevelFactory::setHighScore(const int score) {
 		if(score > _highScore) {
 			_highScore = score;

--- a/source/Objects/Level.cpp
+++ b/source/Objects/Level.cpp
@@ -172,7 +172,7 @@ namespace SuperHaxagon {
 	}
 
 	void Level::left(const float dilation) {
-		_cursorPos -= _factory->getSpeedCursor() * dilation*_multiplierWalls;
+		_cursorPos -= _factory->getSpeedCursor() * dilation * _multiplierWalls;
 	}
 
 	void Level::right(const float dilation) {

--- a/source/Objects/Level.cpp
+++ b/source/Objects/Level.cpp
@@ -172,11 +172,11 @@ namespace SuperHaxagon {
 	}
 
 	void Level::left(const float dilation) {
-		_cursorPos -= _factory->getSpeedCursor() * dilation;
+		_cursorPos -= _factory->getSpeedCursor() * dilation*_multiplierWalls;
 	}
 
 	void Level::right(const float dilation) {
-		_cursorPos += _factory->getSpeedCursor() * dilation;
+		_cursorPos += _factory->getSpeedCursor() * dilation * _multiplierWalls;
 	}
 
 	void Level::clamp() {

--- a/source/Objects/Level.cpp
+++ b/source/Objects/Level.cpp
@@ -144,7 +144,16 @@ namespace SuperHaxagon {
 
 			// For all walls
 			for(const auto& wall : pattern.getWalls()) {
-				const auto check = wall.collision(cursorDistance, _cursorPos, _factory->getSpeedCursor() * dilation/_multiplierWallsOriginal*_multiplierWalls, pattern.getSides());
+
+				// Speed up the cursor over time so movements are always possible
+				const float cursorSpeedMultiplier = _multiplierWalls / STARTING_MULTIPLIER_WALLS;
+
+				const auto check = wall.collision(
+						cursorDistance,
+						_cursorPos,
+						_factory->getSpeedCursor() * dilation  * cursorSpeedMultiplier,
+						pattern.getSides()
+				);
 
 				// Update collision
 				if(collision == Movement::CAN_MOVE) collision = check; //If we can move, try and replace it with something else
@@ -172,11 +181,13 @@ namespace SuperHaxagon {
 	}
 
 	void Level::left(const float dilation) {
-		_cursorPos -= _factory->getSpeedCursor() * dilation / _multiplierWallsOriginal * _multiplierWalls;
+		const float cursorSpeedMultiplier = _multiplierWalls / STARTING_MULTIPLIER_WALLS;
+		_cursorPos -= _factory->getSpeedCursor() * dilation * cursorSpeedMultiplier;
 	}
 
 	void Level::right(const float dilation) {
-		_cursorPos += _factory->getSpeedCursor() * dilation / _multiplierWallsOriginal * _multiplierWalls;
+		const float cursorSpeedMultiplier = _multiplierWalls / STARTING_MULTIPLIER_WALLS;
+		_cursorPos += _factory->getSpeedCursor() * dilation * cursorSpeedMultiplier;
 	}
 
 	void Level::clamp() {

--- a/source/Objects/Level.cpp
+++ b/source/Objects/Level.cpp
@@ -144,7 +144,7 @@ namespace SuperHaxagon {
 
 			// For all walls
 			for(const auto& wall : pattern.getWalls()) {
-				const auto check = wall.collision(cursorDistance, _cursorPos, _factory->getSpeedCursor() * dilation, pattern.getSides());
+				const auto check = wall.collision(cursorDistance, _cursorPos, _factory->getSpeedCursor() * dilation/_multiplierWallsOriginal*_multiplierWalls, pattern.getSides());
 
 				// Update collision
 				if(collision == Movement::CAN_MOVE) collision = check; //If we can move, try and replace it with something else
@@ -172,11 +172,11 @@ namespace SuperHaxagon {
 	}
 
 	void Level::left(const float dilation) {
-		_cursorPos -= _factory->getSpeedCursor() * dilation * _multiplierWalls;
+		_cursorPos -= _factory->getSpeedCursor() * dilation / _multiplierWallsOriginal * _multiplierWalls;
 	}
 
 	void Level::right(const float dilation) {
-		_cursorPos += _factory->getSpeedCursor() * dilation * _multiplierWalls;
+		_cursorPos += _factory->getSpeedCursor() * dilation / _multiplierWallsOriginal * _multiplierWalls;
 	}
 
 	void Level::clamp() {

--- a/source/Objects/Level.hpp
+++ b/source/Objects/Level.hpp
@@ -85,6 +85,7 @@ namespace SuperHaxagon {
 		
 		float _multiplierRot = 0.9f; // Current direction and speed of rotation
 		float _multiplierWalls = 0.85f; // Current speed of the walls flying at you
+		float _multiplierWallsOriginal = _multiplierWalls; // needed to bring cursor speed back to what it was later.
 		float _cursorPos{};
 		float _rotation{};
 		float _sidesTween{};

--- a/source/Objects/Level.hpp
+++ b/source/Objects/Level.hpp
@@ -16,8 +16,10 @@ namespace SuperHaxagon {
 
 	class Level {
 	public:
+		static constexpr float STARTING_MULTIPLIER_WALLS = 0.85f;
+		static constexpr float STARTING_MULTIPLIER_ROT = 0.9f;
 		static constexpr float DIFFICULTY_SCALAR_WALLS = 0.0375f;
-		static constexpr float DIFFICULTY_SCALAR_ROT = 0.08f;
+		static constexpr float DIFFICULTY_SCALAR_ROT = 0.07f;
 		static constexpr float FLIP_FRAMES_MIN = 120.0f;
 		static constexpr float FLIP_FRAMES_MAX = 600.0f;
 		static constexpr float FRAMES_PER_CHANGE_SIDE = 30.0f;
@@ -83,9 +85,8 @@ namespace SuperHaxagon {
 		bool _showCursor = true;
 		bool _rotateToZero = false;
 		
-		float _multiplierRot = 0.9f; // Current direction and speed of rotation
-		float _multiplierWalls = 0.85f; // Current speed of the walls flying at you
-		float _multiplierWallsOriginal = _multiplierWalls; // needed to bring cursor speed back to what it was later.
+		float _multiplierRot = STARTING_MULTIPLIER_ROT; // Current direction and speed of rotation
+		float _multiplierWalls = STARTING_MULTIPLIER_WALLS; // Current speed of the walls flying at you
 		float _cursorPos{};
 		float _rotation{};
 		float _sidesTween{};


### PR DESCRIPTION
This ensures that a pattern that's doable at the start of the level is also doable at the end of the level with the same motions. 

TODO: adjust the initial speed of the cursor in the opposite directions so it's the same as it was before this commit.